### PR TITLE
update 5.2.4 -> 5.3.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "aclist";
     repo = "dztui";
     rev = "release/${version}";
-    sha256 = "";
+    sha256 = "sha256-bTn5O/NhrP0zwmOlvSLofYzB6PifXYT1KCF2MErRFZo=";
   };
 
   postPatch = ''

--- a/default.nix
+++ b/default.nix
@@ -13,13 +13,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "dzgui";
-  version = "5.2.4";
+  version = "5.3.2";
 
   src = fetchFromGitHub {
     owner = "aclist";
     repo = "dztui";
     rev = "release/${version}";
-    sha256 = "sha256-fBsowbZPH5KgVvvrnxzdA2oEeEd802jt27yySrLgNqM=";
+    sha256 = "";
   };
 
   postPatch = ''


### PR DESCRIPTION
Hi! First of all, thank you for this flake, I'm newbie in NixOS and wondered how to set up dzgui in here.

I tried latest version of your  flake and run into problem:
`nix shell github:lelgenio/dzgui-nix --command dzgui` threw error:

```
error: builder for '/nix/store/x8vmr75ybqkh6kir9gqq3z5b5x6kwwfi-source.drv' failed with exit code 1;
       last 8 log lines:
       >
       > trying https://github.com/aclist/dztui/archive/release/5.2.4.tar.gz
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       >   0    14    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (56) The requested URL returned error: 404
       > error: cannot download source from any mirror
       For full logs, run 'nix log /nix/store/x8vmr75ybqkh6kir9gqq3z5b5x6kwwfi-source.drv'.
error: 1 dependencies of derivation '/nix/store/1jw2yfpm2c8hm69bpmp1rcyba5118j4n-dzgui-5.2.4.drv' failed to build
```

I know almost nothing about flakes, but I tried trial and error method and got it working. I changed version to newer one and then it worked:
`nix shell github:PhysShell/dzgui-nix --command dzgui`. I thought maybe it'd be useful for you.