### PR TITLE
feat: update flake and fix package zenity

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714562304,
-        "narHash": "sha256-Mr3U37Rh6tH0FbaDFu0aZDwk9mPAe7ASaqDOGgLqqLU=",
+        "lastModified": 1732812356,
+        "narHash": "sha256-LNcgjOLArRlx2W6XSi0yc0xwLjrK3KF9LxAMqUgFDgw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcd44e224fd68ce7d269b4f44d24c2220fd821e7",
+        "rev": "581d7e4d23b91daf2afa0005a5d3d01d6a8884fe",
         "type": "github"
       },
       "original": {

--- a/package/default.nix
+++ b/package/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  pkgs,
   fetchFromGitHub,
   makeWrapper,
   curl,
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
 
     wmctrl
     xdotool
-    gnome.zenity
+    pkgs.zenity
 
     ## Here we don't declare steam as a dependency because
     ## we could either use the native or flatpack version


### PR DESCRIPTION
Zenity got moved from `gnome.zenity` to namespace `zenity` and therefore does not work on systems that have a newer nixpkgs config.