### PR TITLE
fix: wrapGAppsHook has been renamed to wrapGAppsHook3

### DIFF
--- a/package/default.nix
+++ b/package/default.nix
@@ -11,7 +11,7 @@
   xdotool,
   gnome,
   gobject-introspection,
-  wrapGAppsHook,
+  wrapGAppsHook3,
 }:
 stdenv.mkDerivation rec {
   pname = "dzgui";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook3
   ];
 
   runtimeDeps = [


### PR DESCRIPTION
Hi there, the package has been renamed and my system build was failing.
Should fix for `nixos-unstable`, [see](https://github.com/NixOS/nixpkgs/commit/853d9f31ea6206e86b72db1ba221a12cb503510f)